### PR TITLE
Added github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.yaml
@@ -1,0 +1,39 @@
+name: 🐛 Bug Report
+description: Help us by reporting a bug in the app
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking the time to report a bug!
+  - type: input
+    id: contact
+    attributes:
+      label: (Optional) Contact Details
+      description: How can we reach you in case we need more information?
+      placeholder: email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Explain the problem in detail
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Which version of our software are you using?
+      placeholder: 1.0.0
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: Please copy and paste any logs that may be relevant
+      render: Shell

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yaml
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.yaml
@@ -1,0 +1,39 @@
+name: 🚀 Feature Request
+description: Give us ideas for new features!
+title: "[Enhancement]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for taking your time to give us new ideas!
+  - type: input
+    id: contact
+    attributes:
+      label: (Optional) Contact Details
+      description: How can we reach you in case we need more information?
+      placeholder: email@example.com
+    validations:
+      required: false
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: "Give us a concise description of the suggested feature."
+      placeholder: "Example: Add a button that..."
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Detailed description
+      description: "Describe in detail the feature you would like to see."
+    validations:
+      required: true
+  - type: textarea
+    id: technical
+    attributes:
+      label: (Optional) Technical description
+      description: "Describe how the feature works in a technical level."
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!-- Thanks for contributing to LibrePass.
+Please fill this form to create a new pull request. -->
+
+# PR
+
+## Description
+
+Please include a summary of the change and what problem(s) it solves.
+
+Fixes # (issue)
+
+## Added dependencies
+
+Please list any added dependencies for this change.
+
+## Testing
+
+Please describe all tests ran to verify your changes. Provide instructions to reproduce them. Also list any relevant detail about your testing configuration. Please describe the added unit tests as well.
+
+## Checklist
+
+- [ ] My code follows the coding and style conventions for this project
+- [ ] I made a self-evaluation of my code
+- [ ] I commented my code, specially in hard to understand areas
+- [ ] I made the corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I created unit tests for my code
+- [ ] I ran all the tests available in the project


### PR DESCRIPTION
I created templates for issues and pull requests.

Issue templates use the standart github yaml files and pull requests are a markdown template.

You can see how they work by trying to create a issue/PR in my https://github.com/VewTech/Repo-Template repo (please dont actually create the issue or PR).

This will help future contributors by making it easier to use the application.